### PR TITLE
Add a service to test if any RP1 displays are connected to Pi5

### DIFF
--- a/debian/gldriver-test.rp1-test.service
+++ b/debian/gldriver-test.rp1-test.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Check for RP1 displays for Xorg
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/systemd/scripts/rp1_test.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/rules
+++ b/debian/rules
@@ -26,3 +26,4 @@
 override_dh_installsystemd:
 	dh_installsystemd --name=gldriver-test
 	dh_installsystemd --name=glamor-test
+	dh_installsystemd --name=rp1-test

--- a/usr/lib/systemd/scripts/rp1_test.sh
+++ b/usr/lib/systemd/scripts/rp1_test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Choose an appropriate "Primary GPU" for Xorg
+# This should normally be vc4 (not v3d) but when some
+# other display is enabled on Pi5, it should match that.
+
+IDENTIFIER=vc4
+MATCHDRIVER=vc4
+
+if raspi-config nonint is_pifive; then
+  if ls /dev/dri/by-path/ | grep -q '\(vec\|dsi\|dpi\)-card' ; then
+    IDENTIFIER=rp1
+    MATCHDRIVER='rp1-vec|rp1-dsi|rp1-dpi'
+  fi
+fi
+
+sed -e "s/XXX/${IDENTIFIER}/" << EOF | sed -e "s/YYY/${MATCHDRIVER}/" > /etc/X11/xorg.conf.d/99-v3d.conf.tmp
+Section "OutputClass"
+  Identifier "XXX"
+  MatchDriver "YYY"
+  Driver "modesetting"
+  Option "PrimaryGPU" "true"
+EndSection
+EOF
+
+mv -f /etc/X11/xorg.conf.d/99-v3d.conf.tmp /etc/X11/xorg.conf.d/99-v3d.conf
+


### PR DESCRIPTION
To selectively change the Xorg config to choose a "primary GPU".

On a non-Pi5 or on a Pi5 with no RP1 displays enabled, this should generate the existing `/etc/X11/xorg.conf.d/99-v3d.conf` file (and I suggest we do want to re-generate it every time, in case the SD Card is swapped between Pi4 and Pi5?)

Test procedure:

- Pi5, configure for auto-login to X11
- Connect the official 7" display to either MIPI port, and connect 5V supply via the header
- It will not work without the change, and should work with the change
- Remove the display or set `display_auto_detect=0`; it should work with and without the change
- Can likewise test with TV Out, if a suitable header is fitted; enable and disable Composite Video in `raspi-config`.

Test holes:

- This PR is based on a working script, but I have not tested the installation procedure
- I have not tested X on a SPI display or any other non-HVS non-RP1 display type

It's still unclear if this is the best way to achieve this or the best place to do it, but it does fix an existing problem.